### PR TITLE
Remove leading slash from S3 location

### DIFF
--- a/tutors3/patches/openedx-common-settings
+++ b/tutors3/patches/openedx-common-settings
@@ -16,3 +16,6 @@ is_secure = {{ "True" if S3_USE_SSL else "False" }}
 [s3]
 host = {{ S3_HOST }}:{{ S3_PORT }}
 calling_format = boto.s3.connection.OrdinaryCallingFormat""")
+
+# S3BotoStorage.location cannot begin with a leading slash
+MEDIA_ROOT = "openedx/media/"


### PR DESCRIPTION
S3BotoStorage.location cannot begin with a leading slash